### PR TITLE
Update admin-referral-sale-email.php

### DIFF
--- a/emails/admin-referral-sale-email.php
+++ b/emails/admin-referral-sale-email.php
@@ -71,4 +71,6 @@ function affwp_custom_referral_sale_email( $add ) {
 	$emails->send( $email, $subject, $message );
 
 }
-add_action( 'affwp_insert_referral', 'affwp_custom_referral_sale_email' );
+
+// Send email when referral is complete (status = paid)
+add_action( 'affwp_complete_referral', 'affwp_custom_referral_sale_email' );


### PR DESCRIPTION
The hook stated in the code executed email sending after 'affwp_insert_referral' event which did not display product information in the email sent out.

`add_action( 'affwp_insert_referral', 'affwp_custom_referral_sale_email' );`

This is fixed using 'affwp_complete_referral' event as used in the default plugin.

```
// Send email when referral is complete (status = paid)
add_action( 'affwp_complete_referral', 'affwp_custom_referral_sale_email' );
```

Solves #35